### PR TITLE
Change bars to be relative to top player

### DIFF
--- a/src/routes/live/dps/+page.svelte
+++ b/src/routes/live/dps/+page.svelte
@@ -46,6 +46,8 @@
     },
   });
 
+  let maxDamage = $derived(dpsPlayersWindow.playerRows.reduce((max, p) => (p.totalDmg > max ? p.totalDmg : max), 0n));
+
   let SETTINGS_YOUR_NAME = $derived(settings.state["general"]["showYourName"]);
   let SETTINGS_OTHERS_NAME = $derived(settings.state["general"]["showOthersName"]);
 </script>
@@ -68,7 +70,7 @@
           {#each row.getVisibleCells() as cell (cell.id)}
             <td><FlexRender content={cell.column.columnDef.cell ?? "UNKNOWN CELL"} context={cell.getContext()} /></td>
           {/each}
-          <td class="-z-1 absolute left-0 h-7" style="background-color: {getClassColor(className)}; width: {row.original.dmgPct}vw;"></td>
+          <td class="-z-1 absolute left-0 h-7" style="background-color: {getClassColor(className)}; width: {maxDamage > 0n ? (Number(row.original.totalDmg) / Number(maxDamage)) * 100 : 0}%;"></td>
         </tr>
       {/each}
     </tbody>

--- a/src/routes/live/dps/skills/+page.svelte
+++ b/src/routes/live/dps/skills/+page.svelte
@@ -59,6 +59,8 @@
     },
   });
 
+  let maxSkillValue = $derived(dpsSkillBreakdownWindow.skillRows.reduce((max, p) => (p.totalDmg > max ? p.totalDmg : max), 0n));
+
   let SETTINGS_YOUR_NAME = $derived(settings.state["general"]["showYourName"]);
   let SETTINGS_OTHERS_NAME = $derived(settings.state["general"]["showOthersName"]);
 </script>
@@ -98,7 +100,7 @@
             {#each row.getVisibleCells() as cell (cell.id)}
               <td><FlexRender content={cell.column.columnDef.cell ?? "UNKNOWN CELL"} context={cell.getContext()} /></td>
             {/each}
-            <td class="-z-1 absolute left-0 h-7" style="background-color: {`color-mix(in srgb, ${getClassColor(className)} 80%, white ${i % 2 === 0 ? '50%' : '20%'})`}; width: {row.original.dmgPct}vw;"></td>
+            <td class="-z-1 absolute left-0 h-7" style="background-color: {`color-mix(in srgb, ${getClassColor(className)} 80%, white ${i % 2 === 0 ? '50%' : '20%'})`}; width: {maxSkillValue > 0n ? (Number(row.original.totalDmg) / Number(maxSkillValue)) * 100 : 0}%;"></td>
           </tr>
         {/if}
       {/each}

--- a/src/routes/live/heal/+page.svelte
+++ b/src/routes/live/heal/+page.svelte
@@ -46,6 +46,8 @@
     },
   });
 
+  let maxHeal = $derived(healPlayersWindow.playerRows.reduce((max, p) => (p.totalDmg > max ? p.totalDmg : max), 0n));
+
   let SETTINGS_YOUR_NAME = $derived(settings.state["general"]["showYourName"]);
   let SETTINGS_OTHERS_NAME = $derived(settings.state["general"]["showOthersName"]);
 </script>
@@ -68,7 +70,7 @@
           {#each row.getVisibleCells() as cell (cell.id)}
             <td><FlexRender content={cell.column.columnDef.cell ?? "UNKNOWN CELL"} context={cell.getContext()} /></td>
           {/each}
-          <td class="-z-1 absolute left-0 h-7" style="background-color: {getClassColor(className)}; width: {row.original.dmgPct}vw;"></td>
+          <td class="-z-1 absolute left-0 h-7" style="background-color: {getClassColor(className)}; width: {maxHeal > 0n ? (Number(row.original.totalDmg) / Number(maxHeal)) * 100 : 0}%;"></td>
         </tr>
       {/each}
     </tbody>

--- a/src/routes/live/heal/skills/+page.svelte
+++ b/src/routes/live/heal/skills/+page.svelte
@@ -59,6 +59,8 @@
     },
   });
 
+  let maxSkillValue = $derived(healSkillBreakdownWindow.skillRows.reduce((max, p) => (p.totalDmg > max ? p.totalDmg : max), 0n));
+
   let SETTINGS_YOUR_NAME = $derived(settings.state["general"]["showYourName"]);
   let SETTINGS_OTHERS_NAME = $derived(settings.state["general"]["showOthersName"]);
 </script>
@@ -98,7 +100,7 @@
             {#each row.getVisibleCells() as cell (cell.id)}
               <td><FlexRender content={cell.column.columnDef.cell ?? "UNKNOWN CELL"} context={cell.getContext()} /></td>
             {/each}
-            <td class="-z-1 absolute left-0 h-7" style="background-color: {`color-mix(in srgb, ${getClassColor(className)} 80%, white ${i % 2 === 0 ? '50%' : '20%'})`}; width: {row.original.dmgPct}vw;"></td>
+            <td class="-z-1 absolute left-0 h-7" style="background-color: {`color-mix(in srgb, ${getClassColor(className)} 80%, white ${i % 2 === 0 ? '50%' : '20%'})`}; width: {maxSkillValue > 0n ? (Number(row.original.totalDmg) / Number(maxSkillValue)) * 100 : 0}%;"></td>
           </tr>
         {/if}
       {/each}


### PR DESCRIPTION
My friend and I prefer it like this because it is far easier to read.


<img width="751" height="521" alt="image" src="https://github.com/user-attachments/assets/a4c2b23c-cd74-4f1a-aebc-0cf109b374a4" />

---

If you want to keep both relative and absolute we can probably make a setting that lets the user switch between them.
