### PR TITLE
Make reset stats remember usernames

### DIFF
--- a/src-tauri/src/live/commands.rs
+++ b/src-tauri/src/live/commands.rs
@@ -91,7 +91,7 @@ pub fn hard_reset(state: tauri::State<'_, EncounterMutex>) {
 pub fn reset_encounter(state: tauri::State<'_, EncounterMutex>) {
     let mut encounter = state.lock().unwrap();
 
-	encounter.resetStats();
+	encounter.reset_stats();
     // encounter.clone_from(&Encounter::default());
 
     info!("encounter reset");

--- a/src-tauri/src/live/commands.rs
+++ b/src-tauri/src/live/commands.rs
@@ -90,7 +90,9 @@ pub fn hard_reset(state: tauri::State<'_, EncounterMutex>) {
 #[specta::specta]
 pub fn reset_encounter(state: tauri::State<'_, EncounterMutex>) {
     let mut encounter = state.lock().unwrap();
-    encounter.clone_from(&Encounter::default());
+
+	encounter.resetStats();
+    // encounter.clone_from(&Encounter::default());
 
     info!("encounter reset");
 }

--- a/src-tauri/src/live/opcodes_models.rs
+++ b/src-tauri/src/live/opcodes_models.rs
@@ -42,7 +42,7 @@ impl Encounter {
 			// For Monsters
 			entity.curr_hp = 0;
 			entity.max_hp = 0;
-			entity.last_notified_hp = None;
+			entity.monster_id = 0;
 		})
 	}
 }
@@ -77,60 +77,6 @@ pub struct Entity {
     pub curr_hp: i32,
     pub max_hp: i32,
     pub monster_id: i32,
-	pub last_notified_hp: Option<i32>,
-}
-
-impl Entity {
-	fn hp_percent(max_hp: i32, new_hp: i32) -> Option<i32> {
-		if max_hp == 0 || new_hp == 0 {
-			None
-		} else {
-			let percent = (new_hp as f32 * 100f32 / max_hp as f32) as i32;
-			Some(percent.clamp(0, 100))
-		}
-	}
-
-	pub fn can_notify(&mut self, new_hp: i32) -> Option<i32> {
-		trace!(
-            "Found crowdsourced monster with Name {} - new {} - old {} - max {} - last {:?}",
-            self.name,
-			new_hp,
-			self.curr_hp,
-			self.max_hp,
-			self.last_notified_hp,
-        );
-
-		const HP_PERCENT_MOD: i32 = 10;
-		const HP_PERCENT_COUNTED_AS_DEAD: i32 = 1;
-
-		let hp_percent = Self::hp_percent(self.max_hp, new_hp).unwrap_or(0);
-
-		if self.last_notified_hp.is_none() {
-			self.last_notified_hp = Some(new_hp);
-			return Some(hp_percent / HP_PERCENT_MOD * HP_PERCENT_MOD);
-		}
-		if self.last_notified_hp.unwrap() == 0 {
-			return None;
-		}
-
-		let hp_diff = self.last_notified_hp.unwrap() - new_hp;
-		let hp_diff_percent = Self::hp_percent(self.max_hp, hp_diff).unwrap_or(0);
-		if hp_diff_percent < HP_PERCENT_MOD {
-			return None;
-		}
-
-		if hp_percent % HP_PERCENT_MOD != 0 && hp_percent > HP_PERCENT_COUNTED_AS_DEAD {
-			return None;
-		}
-
-		if hp_percent <= HP_PERCENT_COUNTED_AS_DEAD {
-			self.last_notified_hp = Some(0);
-			return Some(0);
-		}
-
-		self.last_notified_hp = Some(new_hp);
-		Some(hp_percent)
-	}
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src-tauri/src/live/opcodes_models.rs
+++ b/src-tauri/src/live/opcodes_models.rs
@@ -16,6 +16,34 @@ pub struct Encounter {
     pub local_player: SyncContainerData,
 }
 
+impl Encounter {
+	pub fn resetStats(&mut self) {
+		self.total_dmg = 0;
+		self.total_heal = 0;
+
+		self.entity_uid_to_entity.iter_mut().for_each(|(_, entity)| {
+			// Damage
+			entity.total_dmg = 0;
+			entity.crit_total_dmg = 0;
+			entity.crit_hits_dmg = 0;
+			entity.lucky_total_dmg = 0;
+			entity.lucky_hits_dmg = 0;
+			entity.hits_dmg = 0;
+			// Healing
+			entity.total_heal = 0;
+			entity.crit_total_heal = 0;
+			entity.crit_hits_heal = 0;
+			entity.lucky_total_heal = 0;
+			entity.lucky_hits_heal = 0;
+			entity.hits_heal = 0;
+			// For Monsters
+			entity.curr_hp = 0;
+			entity.max_hp = 0;
+			entity.monster_id = 0;
+		})
+	}
+}
+
 pub type EncounterMutex = Mutex<Encounter>;
 
 #[derive(Debug, Default, Clone)]

--- a/src-tauri/src/live/opcodes_process.rs
+++ b/src-tauri/src/live/opcodes_process.rs
@@ -7,7 +7,7 @@ use crate::live::opcodes_models::{
 use crate::packets::utils::BinaryReader;
 use blueprotobuf_lib::blueprotobuf;
 use blueprotobuf_lib::blueprotobuf::{Attr, EDamageType, EEntityType, SyncContainerData};
-use log::{error, info, warn};
+use log::{error, trace, info, warn};
 use std::default::Default;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src-tauri/src/live/opcodes_process.rs
+++ b/src-tauri/src/live/opcodes_process.rs
@@ -171,7 +171,7 @@ pub fn process_aoi_sync_delta(
             attacker_entity.total_heal += actual_value;
             skill.hits += 1;
             skill.total_value += actual_value;
-            info!(
+            trace!(
                 "heal packet: {attacker_uid} to {target_uid}: {actual_value} heal {} total heal",
                 skill.total_value
             );
@@ -202,7 +202,7 @@ pub fn process_aoi_sync_delta(
             attacker_entity.total_dmg += actual_value;
             skill.hits += 1;
             skill.total_value += actual_value;
-            info!(
+	        trace!(
                 "dmg packet: {attacker_uid} to {target_uid}: {actual_value} dmg {} total dmg",
                 skill.total_value
             );
@@ -332,14 +332,14 @@ fn process_monster_attrs(
                         }
                     }
                 }
-                monster_entity.curr_hp = curr_hp;
+	            monster_entity.curr_hp = curr_hp;
             }
-            #[allow(clippy::cast_possible_truncation)]
-            attr_type::ATTR_MAX_HP => {
-                monster_entity.max_hp =
-                    prost::encoding::decode_varint(&mut raw_bytes.as_slice()).unwrap() as i32
-            }
-            _ => (),
+	        #[allow(clippy::cast_possible_truncation)]
+	        attr_type::ATTR_MAX_HP => {
+		        monster_entity.max_hp =
+			        prost::encoding::decode_varint(&mut raw_bytes.as_slice()).unwrap() as i32
+	        }
+	        _ => (),
         }
     }
 }


### PR DESCRIPTION
It feels nice to be able to reset the stats mid dungeon when in a grouped setup.
Might not be perfectly done, but works well.